### PR TITLE
Update to Yardl 0.3.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
+ARG DEVCONTAINER_BASE=mcr.microsoft.com/devcontainers/base:1.0.9-ubuntu-22.04
+
 #########################################################
 # file-normalizer stage
 # In order to use BuildKit remote caching, input files must have
@@ -7,7 +9,7 @@
 # subsequent stage and normalize the permissions.
 #########################################################
 
-FROM mcr.microsoft.com/oss/busybox/busybox:1.33.1 as file-normalizer
+FROM --platform=linux/amd64 ${DEVCONTAINER_BASE} as file-normalizer
 
 COPY environment.yml \
      .devcontainer/devcontainer.bashrc  \
@@ -20,7 +22,7 @@ RUN chmod -R 555 /data/
 # Installs all dependencies and tooling for development.
 #########################################################
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:0.201.8-focal AS devcontainer
+FROM --platform=linux/amd64 ${DEVCONTAINER_BASE} AS devcontainer
 
 # Install needed packages and setup non-root user.
 ARG USERNAME="vscode"
@@ -89,9 +91,8 @@ RUN mkdir -p /home/vscode/.local/share/CMakeTools \
     && chown vscode:conda /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json
 
 # Install the yardl tool
-ARG YARDL_VERSION=0.3.1
+ARG YARDL_VERSION=0.3.2
 RUN wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && mv yardl "/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin/" \
     && rm "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
-    

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--platform=linux/amd64"],
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           mkdir ${YARDL_DIR}
           cd ${YARDL_DIR}
           echo "${{github.workspace}}/yardl" >> $GITHUB_PATH
-          YARDL_VERSION=0.3.1
+          YARDL_VERSION=0.3.2
           wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
           tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
           rm "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"


### PR DESCRIPTION
## Changes in this pull request
Updating Yardl to version [0.3.2](https://github.com/microsoft/yardl/releases/tag/v0.3.2). Also ensured that the devcontainer works on Apple silicon by forcing amd64 images and thus forcing emulation. This is required as there is no xtensor-fftw and xtensor combination that works on arm64. 

## Testing performed
Verified the devcontainer image on Intel and Apple silicon.

## Related issues
<!-- Use keywords such as "fixes", "closes", see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings/doxygen in line with the guidance in the developer guide
- [x] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
