### PR TITLE
Clone submodules on devcontainer start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,14 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--platform=linux/amd64"],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--platform=linux/amd64"
+  ],
+
+  "postStartCommand": "git submodule update --init --recursive",
 
   // Configure tool-specific properties.
   "customizations": {


### PR DESCRIPTION
## Changes in this pull request

Ensure the the submodule is cloned when the devcontainer starts.

## Testing performed


## Related issues


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [] I have added docstrings/doxygen in line with the guidance in the developer guide
- [X] The code builds and runs on my machine

## Contribution Notes

Please read and adhere to the [contribution guidelines](https://github.com/ETSInitiative/PRDdefinition/blob/master/CONTRIBUTING.md).

Please tick the following: 

 - [X] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
