### PR TITLE
Update to PETSIRD v0.2.0 and adapt Python documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Python
         run: |
+          pip install ./PETSIRD/python
           cd python
-          pip install .
           python start.py
 
       - name: Cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Python
         run: |
           cd python
+          pip install .
           python start.py
 
       - name: Cpp

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,9 @@
 # PETSIRD basic Python example
 
-This directory contains some instructions to wrote Python code to read/write PETSIRD data. You need to `yardl generate` in the `model` directory first.
+As you can now install the `petsird` package from PyPI, you likely no longer
+need this repository and can just use `pip install petsird`.
+You can of course use the Python package generated from the local PETSIRD
+clone (`cd python; pip install .`). See
+https://github.com/ETSInitiative/PETSIRD/tree/main/python#readme
+for more information.
 
-As we currently do not have a `set_up.py` for PETSIRD yet, the example file hard-codes the path to the generated files.
-Alternatives would be to use the `PYTHONPATH` environment variable or symbolic links.

--- a/python/start.py
+++ b/python/start.py
@@ -1,5 +1,4 @@
 import sys
-# Currently hard-wire location of generated files. This will need to change!
-sys.path.append('../PETSIRD/python/')
 import petsird
+help(petsird.BinaryPETSIRDReader)
 


### PR DESCRIPTION
As we can now do `pip install petsird`, the Python situation is a lot easier...