### PR TITLE
update to PETSIRD 0.7.2 and remove python

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir -p /home/vscode/.local/share/CMakeTools \
     && chown vscode:conda /home/vscode/.local/share/CMakeTools/cmake-tools-kits.json
 
 # Install the yardl tool
-ARG YARDL_VERSION=0.6.2
+ARG YARDL_VERSION=0.6.3
 RUN wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" \
     && mv yardl "/opt/conda/envs/${CONDA_ENVIRONMENT_NAME}/bin/" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,13 @@ jobs:
         with:
           activate-environment: yardl
           environment-file: temp-ci-environment.yml
+          miniforge-version: latest
       - name: Install yardl
         run: |
           rm temp-ci-environment.yml
           YARDL_DIR=${{github.workspace}}/yardl
           mkdir ${YARDL_DIR}
-          YARDL_VERSION=0.6.2
+          YARDL_VERSION=0.6.3
           wget --quiet "https://github.com/microsoft/yardl/releases/download/v${YARDL_VERSION}/yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
           tar -xzf "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz" -C "${YARDL_DIR}"
           rm "yardl_${YARDL_VERSION}_linux_x86_64.tar.gz"
@@ -47,12 +48,6 @@ jobs:
         run: |
           cd PETSIRD/model
           yardl generate
-
-      - name: Python
-        run: |
-          pip install ./PETSIRD/python
-          cd python
-          python start.py
 
       - name: Cpp
         run: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# PETSIRD template for use cases
+# PETSIRD template for C++ use cases
 
 The purpose of this repo is to provide a starting point for developing software that uses PETSIRD.
-It is currently mostly needed/useful for C++ development, but is also useful for Python developers
-who want to experiment with development of PETSIRD itself.
+It is currently mostly needed/useful for C++ development.
 
 ## Background
 The [Emission Tomography Standardization Initiative (ETSI)](https://etsinitiative.org/)
@@ -18,7 +17,14 @@ These instructions will use `YourRepoName` for the name of your new repository. 
 Easiest is to start from GitHub:
 1. Navigate to the URL of this repo: https://github.com/ETSInitiative/PETSIRDUseCaseTemplate
 2. Click on the `Use this template` button and create your own repo
-3. Pull it to your own local machine and modify
+
+### Using your repo
+
+1. Open ***your*** repo in [GitHub Codespaces](https://code.visualstudio.com/docs/remote/codespaces) or
+in a [VS Code devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
+This codespace/container will contain all necessary tools, including `yardl` itself, as well as your repository.<br>
+(Alternatively, clone to your local computer with `git clone --recurse-submodules <repository_url>`, download `yardl`, install dependencies etc.)
+2. Start with basic house-keeping
    1. Search-and-replace all occurences of `PETSIRDUseCaseTemplate` with `YourRepoName`
    2. Update the README.md to remove references to this template and write something about what your repo is going to do
    3. Update the `environment.yml`to include what you need. For instance, if you need ROOT, add something like `- root=6.28.0`
@@ -27,19 +33,17 @@ Easiest is to start from GitHub:
       git commit -a -m "Updated template to YourRepoName"
       git push
       ```
+3. Start working in the [`cpp`](cpp/README.md) directory.
+4. Edit the [`justfile`](justfile), e.g. to add a `@run` target
+5. type `just build` (or `just run`)
 
-### Using your repo
-
-1. Open ***your*** repo in [GitHub Codespaces](https://code.visualstudio.com/docs/remote/codespaces) or
-in a [VS Code devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
-This codespace/container will contain all necessary tools, including `yardl` itself, as well as your repository.
-2. Use `yardl` to generate C++ and Python code for the model:
-  ```sh
-  cd YourRepoName
-  cd PETSIRD/model
-  yardl generate
-  cd ../..
-  ```
-3. Start working in either the [`cpp`](cpp/README.md) and/or [`python`](python/README.md) directories.
+Note: if you don't want to use `just`, you will have to use `yardl` to generate C++ and Python
+code for the model:
+```sh
+cd YourRepoName
+cd PETSIRD/model
+yardl generate
+cd ../..
+```
 
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.12.0) # older would work, but could give warnings on policy CMP0074
-project(PETSIRDUseCaseTemplate VERSION 0.2.0)
+project(PETSIRDUseCaseTemplate VERSION 0.7.2)
 
 set(CMAKE_CXX_STANDARD 17)
+
+#Set the build type to Release if not specified
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING
+            "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
+            FORCE)
+endif ()
 
 if(WIN32)
   add_compile_options(/W3 /WX)
@@ -9,9 +16,21 @@ else()
   add_compile_options(-Wall -Wextra -pedantic)
 endif()
 
+set(PETSIRD_dir ../PETSIRD/cpp/generated)
+add_subdirectory(${PETSIRD_dir} PETSIRD_generated)
+
+# Add any packages, below is an example for ROOT (unlikely you'll need that one though!)
+# find_package(ROOT REQUIRED COMPONENTS Tree)
+
 # Example lines for a new executable
 # add_executable(my_prog my_prog.cpp)
+# target_include_directories(my_prog PUBLIC ${PETSIRD_dir})
+# needed for helpers
+# target_include_directories(my_prog PUBLIC ${PETSIRD_dir}/..)
+# target_include_directories(my_prog PUBLIC ${PETSIRD_dir}/../helpers/include)
 # target_link_libraries(my_prog PUBLIC petsird_generated)
-# install(TARGETS my_prog DESTINATION bin)
 
-add_subdirectory(../PETSIRD/cpp/generated PETSIRD_generated)
+# add any dependencies on packages here
+# target_link_libraries(my_prog PUBLIC ROOT::Tree)
+
+# install(TARGETS my_prog DESTINATION bin)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,7 +2,7 @@
 
 This directory provides a skeleton for C++ example code to read/write PETSIRD data. You need to `yardl generate` in the `model` directory first.
 
-Check the example in the PRDdefinition repo first.
+Check the example in the PETSIRD repo first.
 
 1. Compile the code:
    ```sh

--- a/environment.yml
+++ b/environment.yml
@@ -6,16 +6,12 @@ dependencies:
   - bash-completion>=2.11
   - cmake>=3.21.3
   - fmt>=8.1.1
-  - compilers
-  - h5py>=3.7.0
+  - cxx-compiler
   - hdf5>=1.12.1
   - howardhinnant_date>=3.0.1
-  - ipykernel>=6.19.2
+  - just=1.36.0
   - ninja>=1.11.0
   - nlohmann_json>=3.11.2
-  - numpy>=1.24.3
-  - python>=3.11.3
-  - matplotlib
   - shellcheck>=0.8.0
-  - xtensor-fftw>=0.2.5
-  - xtensor>=0.24.2
+  - xtensor>=0.24.2, <0.26.0
+  - xtensor-blas

--- a/justfile
+++ b/justfile
@@ -1,0 +1,19 @@
+set shell := ['bash', '-ceuo', 'pipefail']
+
+default: run
+
+@ensure-build-dir:
+    mkdir -p cpp/build
+
+@generate:
+    cd PETSIRD/model; \
+    yardl generate
+
+@configure: generate ensure-build-dir
+    cd cpp/build; \
+    cmake -GNinja ..
+
+@build: generate configure
+    cd cpp/build; \
+    ninja
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,9 +1,0 @@
-# PETSIRD basic Python example
-
-As you can now install the `petsird` package from PyPI, you likely no longer
-need this repository and can just use `pip install petsird`.
-You can of course use the Python package generated from the local PETSIRD
-clone (`cd python; pip install .`). See
-https://github.com/ETSInitiative/PETSIRD/tree/main/python#readme
-for more information.
-

--- a/python/start.py
+++ b/python/start.py
@@ -1,4 +1,0 @@
-import sys
-import petsird
-help(petsird.BinaryPETSIRDReader)
-


### PR DESCRIPTION
## Changes in this pull request
- update PETSIRD submodule and environment
- use yardl 0.6.3
- remove python example as it's not really useful now that we have PyPI and conda-forge
- update doc a bit

## Contribution Notes

- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in the ETSI software (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
